### PR TITLE
Epoch Modifications

### DIFF
--- a/metevents/events.py
+++ b/metevents/events.py
@@ -23,6 +23,10 @@ class BaseEvents:
     def N(self):
         return len(self.events)
 
+    @property
+    def values(self):
+        return [e.value for e in self.events]
+
     def find(self, *args, **kwargs):
         """
         Function to be defined for specific events in timeseries data. Performs
@@ -151,8 +155,6 @@ class OutlierEvents(BaseEvents):
     def __init__(self, data):
         super().__init__(data)
 
-        self.outliers = None
-
     def find(self):
         """
                 Find periods that were outliers for the given dataset using a Z-score ??
@@ -171,8 +173,13 @@ class OutlierEvents(BaseEvents):
         is_outlier = (z_score > 3) | (z_score < -3)
 
         # only save outliers
-        outlier = BaseEpoch()
-        outlier.value = data.values[is_outlier]
-        outlier.date = data.index[is_outlier]
+        for d, v in data[is_outlier].items():
+            self._events.append(BaseEpoch(v, d))
 
-        self.outliers = outlier
+    @property
+    def outliers(self):
+        return self._events
+
+    @property
+    def dates(self):
+        return [e.date for e in self.events]

--- a/metevents/periods.py
+++ b/metevents/periods.py
@@ -50,6 +50,6 @@ class CumulativePeriod(BaseTimePeriod):
 
 class BaseEpoch:
 
-    def __int__(self, value, date):
+    def __init__(self, value, date):
         self.value = value
         self.date = date

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -102,8 +102,7 @@ class TestOutlierEvents:
     ])
     def test_outliers_value(self, outlier_storms, data, outliers_value):
         outlier_storms.find()
-        results = outlier_storms.outliers.value
-        assert np.all(results == outliers_value)
+        assert np.all(outlier_storms.values == outliers_value)
 
     @pytest.mark.parametrize('data, outliers_date', [
         ([2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
@@ -112,8 +111,7 @@ class TestOutlierEvents:
     ])
     def test_outliers_date(self, outlier_storms, data, outliers_date):
         outlier_storms.find()
-        results = outlier_storms.outliers.date
-        assert np.all(results == outliers_date)
+        assert np.all(outlier_storms.dates == outliers_date)
 
     @pytest.mark.parametrize('data', [
         ([2, 2, 2, 2])
@@ -136,7 +134,7 @@ class TestOutlierEvents:
 
         outlier_storms.find()
         tolerance = 1e-10
-        results = outlier_storms.outliers.value
+        results = outlier_storms.values
         expect_value = pytest.approx(out_value, rel=tolerance, abs=tolerance)
         assert np.all(results == expect_value)
 
@@ -156,7 +154,7 @@ class TestOutlierEvents:
         )
 
         outlier_storms.find()
-        results = outlier_storms.outliers.date
+        results = outlier_storms.dates
         assert np.all(results == out_date)
 
     @pytest.mark.parametrize('station_id, start, stop, source', [


### PR DESCRIPTION
I wanted to show you what I was scheming here. 

1. The goal here is to maintain similar structure and usage as the previous classes. e.g. using `self.events` instead of a new structure `self.outliers`. Not to say its a bad way to do it, but if someone new were to pick up metevents they would need to know all the sub properties instead of just learning all Event classes work basically the same way. Each Event class is about something specific (outliers in this case) and self.events holds all the instances where we found what that class is focused on. 
2. In this same way, we want to model the new `BaseEpoch` class as close to the `BaseTimePeriod` class as possible. Where each class holds a singular event. The approach you had before was not bad but was different than the `BaseTimePeriod` class in that your version of `BaseEpoch` held all the outliers instead of a bunch of Epoch objects each holding a single outlier from the time series.

3. Something I saw in your tests made me think we could use a couple properties for extracting the values/dates out so I added that in too just for convenience. 
4. I added an outliers property so you could use that attribute if a user wanted to. It just reflects events. 


Take a look, feel free to ask any questions and when you are ready merge it into yours. 
 